### PR TITLE
Hide weather API key behind a Cloudflare Worker proxy; remove bookmarks

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,0 +1,26 @@
+name: Deploy Worker
+
+# Auto-deploys the weather proxy whenever the worker changes.
+# Requires a repo secret CLOUDFLARE_API_TOKEN (Cloudflare dashboard ->
+# My Profile -> API Tokens -> "Edit Cloudflare Workers" template).
+# The OWM_API_KEY secret is set once with `wrangler secret put` and persists
+# on Cloudflare across deploys, so it does not need to live in GitHub.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'worker/**'
+      - '.github/workflows/deploy-worker.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy Worker
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          workingDirectory: worker

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 .DS_Store
+
+# Cloudflare Worker tooling
+node_modules/
+.wrangler/
+.dev.vars

--- a/README.md
+++ b/README.md
@@ -2,10 +2,27 @@
 This is a very simple html/css landing page to serve as my new tab.
 Currently hosted at ankitsachdeva.com/new-tab
 
+## Weather
+The weather widget calls a small [Cloudflare Worker](worker/worker.js) proxy
+instead of OpenWeatherMap directly, so the API key is never exposed in the
+page. The key is stored as an encrypted Worker secret, not in this repo.
+
+Setup (free — Cloudflare Workers free tier):
+```sh
+cd worker
+npm install -g wrangler        # if you don't have it
+wrangler login
+wrangler secret put OWM_API_KEY # paste your OpenWeatherMap key when prompted
+wrangler deploy
+```
+Then put the deployed `*.workers.dev` URL into the `xhr.open(...)` call in
+`index.html` (replace `YOUR-SUBDOMAIN`).
+
 ## Personalization
-Feel free to use this for your own use. You will need to change the following:
-- Location tag on weather script (feel free to use my API key)
-- bookmarks
+Feel free to use this for your own use. You will need to:
+- Set your own `OWM_API_KEY` secret and weather location (the `id` in
+  `worker/worker.js`)
+- Point `ALLOWED_ORIGIN` in the Worker at your own domain
 
 ## Usage
 - press space to enter search mode (currently google)

--- a/README.md
+++ b/README.md
@@ -12,9 +12,16 @@ Setup (free — Cloudflare Workers free tier):
 cd worker
 npm install -g wrangler        # if you don't have it
 wrangler login
-wrangler secret put OWM_API_KEY # paste your OpenWeatherMap key when prompted
+
+# OWM_API_KEY is the secret NAME, not the value. Paste the key when prompted:
+wrangler secret put OWM_API_KEY
+
 wrangler deploy
 ```
+First deploy only: if wrangler reports you have no `workers.dev` subdomain,
+register one at the dashboard link it prints (one-time), then re-run
+`wrangler deploy`.
+
 Then put the deployed `*.workers.dev` URL into the `xhr.open(...)` call in
 `index.html` (replace `YOUR-SUBDOMAIN`).
 

--- a/index.html
+++ b/index.html
@@ -46,10 +46,8 @@
         window.onload = () => {
             let xhr = new XMLHttpRequest();
             // Weather is fetched through a Cloudflare Worker proxy that keeps the
-            // OpenWeatherMap API key as a secret, so the key never ships to the
-            // browser. Replace YOUR-SUBDOMAIN with your workers.dev subdomain
-            // (see the URL printed by `wrangler deploy`).
-            xhr.open('GET', 'https://nt-weather.YOUR-SUBDOMAIN.workers.dev');
+            // OpenWeatherMap API key as a secret, so the key never ships to the browser.
+            xhr.open('GET', 'https://nt-weather.ankitsachdeva001.workers.dev');
             xhr.onload = () => {
                 if (xhr.readyState === 4) {
                     if (xhr.status === 200) {

--- a/index.html
+++ b/index.html
@@ -22,54 +22,6 @@
                 <div id="temp" class="inline"></div>
             </div>
         </div>
-        <div class="bookmark-container">
-            <div class="bookmark-set">
-                <div class="bookmark-title">School</div>
-                <div class="bookmark-inner-container">
-                    <a class="bookmark" href="https://mail.gatech.edu/" target="_blank">outlook</a>
-                    <a class="bookmark" href="https://gatech.enterprise.slack.com/" target="_blank">slack</a>
-                    <a class="bookmark" href="https://oscar.gatech.edu/" target="_blank">oscar</a>
-                    <a class="bookmark" href="https://canvas.gatech.edu/" target="_blank">canvas</a>
-                    <a class="bookmark" href="https://sso.gatech.edu/cas/login?service=https%3A%2F%2Fdegreeaudit.gatech.edu%2Flogin%2Fcas" target="_blank">degree works</a>
-                    <a class="bookmark" href="https://passport.gatech.edu/" target="_blank">passport</a>
-                    <a class="bookmark" href="https://docs.google.com/document/d/1q0y3AlNPT0FGjeKJGFngzRJU54wrWwFRuxn94FthxEE/edit" target="_blank">planning</a>
-                </div>
-            </div>
-
-            <div class="bookmark-set">
-                <div class="bookmark-title">dynaConnections</div>
-                    <a class="bookmark" href="https://bitbucket.org/dynaconnections/connectmls.regression/src/8ddc69b0f834f745ded97edb93b2526f390db92d/?at=release%2Fdev" target="_blank">automation</a>
-                    <a class="bookmark" href="https://dynaconnections.atlassian.net/wiki/spaces/QA/pages/2327085057/Test+Checklists" target="_blank">confluence</a>
-                    <a class="bookmark" href="https://dynaconnections.atlassian.net/jira/software/c/projects/AT/boards/33" target="_blank">kanban</a>
-                    <a class="bookmark" href="https://mred-dev.connectmls.com/" target="_blank">MRED</a>
-                    <a class="bookmark" href="https://mibor-dev.connectmls.com/" target="_blank">MIBOR</a>
-                    <a class="bookmark" href="https://smartmls-dev.connectmls.com/" target="_blank">smartMLS</a>
-                <div class="bookmark-inner-container">
-                </div>
-            </div>
-            
-            <div class="bookmark-set">
-                <div class="bookmark-title">Job Search</div>
-                <div class="bookmark-inner-container">
-                    <a class="bookmark" href="https://youtu.be/o_73FeXw3ZI?si=RwuR0amkTpQGaEm1&t=61" target="_blank">morning yoga</a>
-                    <a class="bookmark" href="https://subs.swingeducation.com/#/" target="_blank">swing</a>
-                    <a class="bookmark" href="https://workforcenow.adp.com/theme/index.html#/Myself/PayandAnnualStatements" target="_blank">adp</a>
-                    <a class="bookmark" href="https://docs.google.com/spreadsheets/d/1J5GXOhb9NfyqIAi0Tnw3SSuezUsMrPP_uuGYFQI1q0k/edit?gid=0#gid=0" target="_blank">applied</a>
-                    <a class="bookmark" href="https://docs.google.com/spreadsheets/d/1mU0lvsgIC0nGp9rDO54SA67HPvnSd6B1X5ldNPQYGiQ/edit?gid=0#gid=0" target="_blank"> apply</a>
-                </div>
-            </div>
-
-            <div class="bookmark-set">
-                <div class="bookmark-title">Code</div>
-                <div class="bookmark-inner-container">
-                  <a class="bookmark" href="https://news.ycombinator.com/" target="_blank">hacker news</a>
-                  <a class="bookmark" href="https://xkcd.com/" target="_blank">xkcd</a>
-                  <a class="bookmark" href="https://leetcode.com/discuss/general-discussion/460599/blind-75-leetcode-questions" target="_blank">blind 75</a>
-                  <a class="bookmark" href="https://designgurus.org/course/grokking-the-coding-interview" target="_blank">grokking</a>
-                  <a class="bookmark" href="https://leetcode.com/problemset/all/" target="_blank">leetcode</a>
-                </div>
-            </div>
-        </div>
     </div>
 
     <script>
@@ -93,8 +45,11 @@
 
         window.onload = () => {
             let xhr = new XMLHttpRequest();
-            // Request to open weather map
-            xhr.open('GET', 'https://api.openweathermap.org/data/2.5/weather?id=4671654&units=imperial&appid=44c9f50e295f8a812f54e3683316132e');
+            // Weather is fetched through a Cloudflare Worker proxy that keeps the
+            // OpenWeatherMap API key as a secret, so the key never ships to the
+            // browser. Replace YOUR-SUBDOMAIN with your workers.dev subdomain
+            // (see the URL printed by `wrangler deploy`).
+            xhr.open('GET', 'https://nt-weather.YOUR-SUBDOMAIN.workers.dev');
             xhr.onload = () => {
                 if (xhr.readyState === 4) {
                     if (xhr.status === 200) {

--- a/style.css
+++ b/style.css
@@ -70,14 +70,6 @@ body {
     display: inline-block;
 }
 
-.bookmark-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    width: 60%;
-    margin: 1em 0em;
-}
-
 @media only screen and (max-width: 960px) {
     .container {
         height: auto;
@@ -85,46 +77,6 @@ body {
     #clock {
         margin-top: 1em;
     }
-    .container > .bookmark-container {
-        flex-direction: column;
-        width: 60%;
-    }
-    .bookmark-container > .bookmark-set {
-        width: auto;
-        margin: 1em 0em;
-    }
-}
-
-.bookmark-set{
-    padding: 1em;
-    background-color: #3b4252;
-    border-radius: 3px;
-    font-family: "Roboto Mono";
-    font-size: .85rem;
-    width: 25%;
-    height: 16em;
-    margin: 0em .5em;
-}
-.bookmark-inner-container {
-    overflow-y: scroll;
-    height: 80%;
-    vertical-align: top;
-}
-.bookmark-title {
-    font-family: "Roboto";
-    font-size: 1.2rem;
-    font-weight: 600;
-    color: #81a1c1;
-    margin: 0em 0em .35em 0em;
-}
-.bookmark {
-    text-decoration: none;
-    color: #5e81ac;
-    display:block;
-    margin: .4em 0em;
-}
-.bookmark:hover {
-    color: #d8dee9;
 }
 
 .city-name {

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,41 @@
+// Cloudflare Worker: weather proxy for the new-tab page.
+//
+// The OpenWeatherMap API key lives only here, as a Worker secret named
+// OWM_API_KEY, set with:
+//
+//     wrangler secret put OWM_API_KEY
+//
+// The browser calls this Worker instead of OpenWeatherMap directly, so the key
+// never ships to the client. Responses are cached for 10 minutes to stay well
+// within the free tier.
+
+const ALLOWED_ORIGIN = "https://ankitsachdeva.com";
+const WEATHER_URL =
+  "https://api.openweathermap.org/data/2.5/weather?id=4671654&units=imperial";
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get("Origin");
+    const cors = {
+      "Access-Control-Allow-Origin":
+        origin === ALLOWED_ORIGIN ? origin : ALLOWED_ORIGIN,
+      "Access-Control-Allow-Methods": "GET, OPTIONS",
+      "Vary": "Origin",
+    };
+
+    if (request.method === "OPTIONS") {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    const upstream = await fetch(`${WEATHER_URL}&appid=${env.OWM_API_KEY}`);
+    const body = await upstream.text();
+    return new Response(body, {
+      status: upstream.status,
+      headers: {
+        ...cors,
+        "Content-Type": "application/json",
+        "Cache-Control": "public, max-age=600",
+      },
+    });
+  },
+};

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,6 @@
+name = "nt-weather"
+main = "worker.js"
+compatibility_date = "2025-01-01"
+
+# The API key is NOT stored here. Set it as an encrypted secret instead:
+#     cd worker && wrangler secret put OWM_API_KEY


### PR DESCRIPTION
## What
- Route the OpenWeatherMap call through a Cloudflare Worker proxy that holds the API key as a secret, so the key never ships to the browser.
- Remove the hardcoded API key from `index.html`; the page now calls the deployed Worker.
- Remove all four bookmark sets (School, dynaConnections, Job Search, Code) and their now-unused CSS.
- Drop the "use my API key" invite from the README; document the proxy/secret setup.
- Add a GitHub Action to auto-deploy the Worker on push (needs a `CLOUDFLARE_API_TOKEN` repo secret).

## Verified
- Worker deployed and live; `curl` returns HTTP 200 weather JSON with no `appid` in the response.

## Follow-ups (outside this PR)
- Deactivate the old API key on OpenWeatherMap (it remains in git history).
- Add the `CLOUDFLARE_API_TOKEN` repo secret so the auto-deploy Action passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)