### PR TITLE
Fix deploy-worker CI: skip when Cloudflare token is absent

### DIFF
--- a/.github/workflows/deploy-worker.yml
+++ b/.github/workflows/deploy-worker.yml
@@ -1,10 +1,11 @@
 name: Deploy Worker
 
 # Auto-deploys the weather proxy whenever the worker changes.
-# Requires a repo secret CLOUDFLARE_API_TOKEN (Cloudflare dashboard ->
-# My Profile -> API Tokens -> "Edit Cloudflare Workers" template).
-# The OWM_API_KEY secret is set once with `wrangler secret put` and persists
-# on Cloudflare across deploys, so it does not need to live in GitHub.
+# To enable deploys, add a repo secret CLOUDFLARE_API_TOKEN (Cloudflare dashboard
+# -> My Profile -> API Tokens -> "Edit Cloudflare Workers" template).
+# Until that secret exists, the deploy step is skipped so CI stays green.
+# The OWM_API_KEY secret is set once with `wrangler secret put` and persists on
+# Cloudflare across deploys, so it does not need to live in GitHub.
 
 on:
   push:
@@ -17,10 +18,20 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Skip deploy (no Cloudflare token)
+        if: ${{ env.CLOUDFLARE_API_TOKEN == '' }}
+        run: |
+          echo "CLOUDFLARE_API_TOKEN is not set — skipping deploy."
+          echo "Add it under Settings -> Secrets and variables -> Actions to enable auto-deploy."
+
       - name: Deploy Worker
+        if: ${{ env.CLOUDFLARE_API_TOKEN != '' }}
         uses: cloudflare/wrangler-action@v3
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          apiToken: ${{ env.CLOUDFLARE_API_TOKEN }}
           workingDirectory: worker


### PR DESCRIPTION
The `deploy-worker` workflow failed on `main` with:

> In a non-interactive environment, it's necessary to set a CLOUDFLARE_API_TOKEN environment variable for wrangler to work.

There's no Cloudflare credential configured, so the deploy can't run.

This gates the deploy step on `CLOUDFLARE_API_TOKEN` so the job **skips gracefully (green)** when the secret is missing, and **auto-deploys** once it's added — no further workflow edits needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)